### PR TITLE
Fix jenv crashing silently

### DIFF
--- a/jenv.bat
+++ b/jenv.bat
@@ -5,11 +5,11 @@ where /q pwsh.exe
 IF ERRORLEVEL 1 (
     where /q powershell.exe
     IF ERRORLEVEL 1 (
-        set ps=powershell.exe
-    ) ELSE (
         echo Neither pwsh.exe nor powershell.exe was found in your path.
         echo Please install powershell it is required
-        exit
+        exit /B
+    ) ELSE (
+        set ps=powershell.exe
     )
 ) ELSE (
     set ps=pwsh.exe


### PR DESCRIPTION
This fixes two issues:
1. On error, the script was closing the entire terminal so we couldn't even see the error output.
2. The logic was incorrect, causing the script to close if `pwsh.exe` didn't exist but `powershell.exe` did.