### PR TITLE
Fixed jenv use on cmd

### DIFF
--- a/jenv.bat
+++ b/jenv.bat
@@ -37,7 +37,7 @@ if exist jenv.use.tmp (
         if "%%x" == "remove" (
             set "JENVUSE="
         ) ELSE (
-            set JENVUSE=%%x   
+            set JENVUSE=%%x
         )
         
     )


### PR DESCRIPTION
Those extra spaces were causing a problem with setting the environment variable.
closes #27 